### PR TITLE
[Docs] 이미지 메타데이터 문서화 리뷰 요청

### DIFF
--- a/src/main/java/com/aetheri/application/port/in/image/DeleteImageMetadataUseCase.java
+++ b/src/main/java/com/aetheri/application/port/in/image/DeleteImageMetadataUseCase.java
@@ -3,8 +3,15 @@ package com.aetheri.application.port.in.image;
 import reactor.core.publisher.Mono;
 
 /**
- * 이미지 삭제 유즈케이스
+ * 이미지 메타데이터 삭제 유즈케이스
  * */
 public interface DeleteImageMetadataUseCase {
+    /**
+     * 이미지 메타데이터를 삭제할 수 있는 메소드
+     *
+     * @param imageId 삭제할 이미지의 ID
+     * @param runnerId 이미지를 삭제할 사용자의 ID
+     * @return 삭제하므로 Void를 리턴한다
+     * */
     Mono<Void> deleteImageMetadata(Long runnerId, Long imageId);
 }

--- a/src/main/java/com/aetheri/application/port/in/image/FindImageMetadataUseCase.java
+++ b/src/main/java/com/aetheri/application/port/in/image/FindImageMetadataUseCase.java
@@ -5,10 +5,35 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * 이미지 조회 유즈케이스
- * */
+ * 이미지 메타데이터 조회 유즈케이스
+ */
 public interface FindImageMetadataUseCase {
+    /**
+     * 사용자의 ID와 이미지의 ID로 메타데이터를 찾을 수 있는 메소드
+     *
+     * @param imageId  조회할 이미지 메타데이터의 ID
+     * @param runnerId 조회를 요청한 사용자의 ID
+     * @implSpec 요청자가 이미지 메타데이터의 소유자인지 검사한다,
+     * @return 이미지 메타데이터 정보를 가진 DTO
+     */
     Mono<ImageMetadataResponse> findImageMetadataById(Long runnerId, Long imageId);
+
+    /**
+     * 이미지의 ID로 메타데이터를 찾을 수 있는 메소드
+     *
+     * @param imageId 조회할 이미지 메타데이터의 ID
+     * @implSpec 요청자의 인증이 없이도 이미지 메타데이터를 조죄할 수 있다.
+     *           하지만 이미지 메타데이터의 상태가 공유되지 않았따면 조회할 수 없다.
+     * @return 이미지 메타데이터의 정보를 가진 DTO
+     */
     Mono<ImageMetadataResponse> findImageMetadataById(Long imageId);
+
+    /**
+     * 사용자의 ID로 이미지 메타데이트롤 찾을 수 있는 메소드
+     *
+     * @param runnerId 이미지 메타데이터를 가진 사용자의 ID
+     * @implSpec FLux로 반환하고 이는 SSE 로 클라이언트로 응답하게 된다.
+     * @return 이미지 메타데이터의 정보를 가진 DTO
+     * */
     Flux<ImageMetadataResponse> findImageMetadataByRunnerId(Long runnerId);
 }

--- a/src/main/java/com/aetheri/application/port/in/image/SaveImageMetadataUseCase.java
+++ b/src/main/java/com/aetheri/application/port/in/image/SaveImageMetadataUseCase.java
@@ -4,7 +4,7 @@ import com.aetheri.application.dto.image.ImageMetadataSaveRequest;
 import reactor.core.publisher.Mono;
 
 /**
- * 이미지 생성 요청 포트
+ * 이미지 메타데이터 생성 요청 포트
  * */
 public interface SaveImageMetadataUseCase {
     Mono<Void> saveImageMetadata(Long runnerId, ImageMetadataSaveRequest request);

--- a/src/main/java/com/aetheri/application/port/in/image/UpdateImageMetadataUseCase.java
+++ b/src/main/java/com/aetheri/application/port/in/image/UpdateImageMetadataUseCase.java
@@ -3,6 +3,18 @@ package com.aetheri.application.port.in.image;
 import com.aetheri.application.dto.image.ImageMetadataUpdateRequest;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터 수정 유즈케이스
+ * */
 public interface UpdateImageMetadataUseCase {
+    /**
+     * 이미지 메타데이터를 수정하기 위한 메소드
+     *
+     * @param runnerId 수정을 요청한 사용자의 ID
+     * @param imageId 수정될 이미지 메타데이터의 ID
+     * @param request 수정할 정보가 담긴 DTO
+     * @implSpec 만약 사용자의 ID와 이미지 메타데이터의 소유자 ID가 다르면 수정할 수 없어야 한다.
+     * @return 수정된 정보를 반환하지 않기에 Void를 반환한다.
+     * */
     Mono<Void> updateImageMetadata(Long runnerId, Long imageId, ImageMetadataUpdateRequest request);
 }

--- a/src/main/java/com/aetheri/application/port/out/image/ImageRepositoryPort.java
+++ b/src/main/java/com/aetheri/application/port/out/image/ImageRepositoryPort.java
@@ -6,12 +6,28 @@ import com.aetheri.infrastructure.persistence.entity.ImageMetadata;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터를 데이터베이스에서 조작하기 위한 포트
+ * */
 public interface ImageRepositoryPort {
+    // 이미지 메타데이터를 등록하기 위한 메소드
     Mono<Long> saveImageMetadata(ImageMetadataSaveDto dto);
+
+    // 이미지 메타데이터를 ID로 조회하기 위한 메소드
     Mono<ImageMetadata> findById(Long imageId);
+
+    // 이미지 메타데이터를 사용자 ID로 조회하기 위한 메소드
     Flux<ImageMetadata> findByRunnerId(Long runnerId);
+
+    // 이미지 메타데이터를 수정하기 위한 메소드
     Mono<Long> updateImageMetadata(Long runnerId, Long imageId, ImageMetadataUpdateRequest request);
+
+    // 이미지 메타데이터가 존재하는지 확인하기 위한 메소드
     Mono<Boolean> isExistImageMetadata(Long imageId);
+
+    // 이미지 메타데이터를 사용자 ID와 이미지 ID를 사용해서 삭제하기 위한 메소드
     Mono<Long> deleteById(Long runnerId, Long imageId);
+
+    // 이미지 메타데이터를 사용자 ID를 사용해서 삭제하기 위한 메소드
     Mono<Long> deleteByRunnerId(Long runnerId);
 }

--- a/src/main/java/com/aetheri/application/port/out/image/ImageRepositoryPort.java
+++ b/src/main/java/com/aetheri/application/port/out/image/ImageRepositoryPort.java
@@ -1,4 +1,17 @@
 package com.aetheri.application.port.out.image;
 
+import com.aetheri.application.dto.image.ImageMetadataSaveDto;
+import com.aetheri.application.dto.image.ImageMetadataUpdateRequest;
+import com.aetheri.infrastructure.persistence.entity.ImageMetadata;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 public interface ImageRepositoryPort {
+    Mono<Long> saveImageMetadata(ImageMetadataSaveDto dto);
+    Mono<ImageMetadata> findById(Long imageId);
+    Flux<ImageMetadata> findByRunnerId(Long runnerId);
+    Mono<Long> updateImageMetadata(Long runnerId, Long imageId, ImageMetadataUpdateRequest request);
+    Mono<Boolean> isExistImageMetadata(Long imageId);
+    Mono<Long> deleteById(Long runnerId, Long imageId);
+    Mono<Long> deleteByRunnerId(Long runnerId);
 }

--- a/src/main/java/com/aetheri/application/service/image/DeleteImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/DeleteImageMetadataService.java
@@ -1,6 +1,7 @@
 package com.aetheri.application.service.image;
 
 import com.aetheri.application.port.in.image.DeleteImageMetadataUseCase;
+import com.aetheri.application.port.out.image.ImageRepositoryPort;
 import com.aetheri.domain.adapter.out.r2dbc.ImageMetadataRepositoryR2dbcAdapter;
 import com.aetheri.domain.exception.BusinessException;
 import com.aetheri.domain.exception.message.ErrorMessage;
@@ -9,15 +10,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터를 삭제하기 위한 서비스
+ *
+ * @implNote DeleteImageMetadataUseCase 유즈케이스를 구현한다
+ * @see DeleteImageMetadataUseCase 구현하는 유즈케이스
+ * @see ImageRepositoryPort 데이터베이스에 접근하기 위해 접근하는 포트
+ * */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeleteImageMetadataService implements DeleteImageMetadataUseCase {
-    private final ImageMetadataRepositoryR2dbcAdapter imageMetadataRepositoryR2DbcAdapter;
+    private final ImageRepositoryPort imageRepositoryPort;
 
     @Override
     public Mono<Void> deleteImageMetadata(Long runnerId, Long imageId) {
-        return imageMetadataRepositoryR2DbcAdapter.deleteById(runnerId, imageId)
+        return imageRepositoryPort.deleteById(runnerId, imageId)
                 .flatMap(deletedCount -> {
                     if (deletedCount == 0) {
                         return Mono.error(new BusinessException(

--- a/src/main/java/com/aetheri/application/service/image/DeleteImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/DeleteImageMetadataService.java
@@ -2,7 +2,6 @@ package com.aetheri.application.service.image;
 
 import com.aetheri.application.port.in.image.DeleteImageMetadataUseCase;
 import com.aetheri.application.port.out.image.ImageRepositoryPort;
-import com.aetheri.domain.adapter.out.r2dbc.ImageMetadataRepositoryR2dbcAdapter;
 import com.aetheri.domain.exception.BusinessException;
 import com.aetheri.domain.exception.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +12,6 @@ import reactor.core.publisher.Mono;
 /**
  * 이미지 메타데이터를 삭제하기 위한 서비스
  *
- * @implNote DeleteImageMetadataUseCase 유즈케이스를 구현한다
  * @see DeleteImageMetadataUseCase 구현하는 유즈케이스
  * @see ImageRepositoryPort 데이터베이스에 접근하기 위해 접근하는 포트
  * */
@@ -23,6 +21,15 @@ import reactor.core.publisher.Mono;
 public class DeleteImageMetadataService implements DeleteImageMetadataUseCase {
     private final ImageRepositoryPort imageRepositoryPort;
 
+    /**
+     * 이미지 메타데이터를 삭제하기 위한 서비스 메소드
+     *
+     * @param runnerId 이미지 메타데이터 삭제를 요청한 사용자의 ID
+     * @param imageId 삭제 요청된 이미지 메타데이터의 ID
+     * @implSpec 만약 삭제된 행의 갯수가 0개라면 삭제되지 않았다고 판단하고 에러 응답
+     * @exception BusinessException 삿제된 행의 갯수가 0개일 때 에러 반환
+     * @return 아무런 정보도 응답하지 않는다.
+     * */
     @Override
     public Mono<Void> deleteImageMetadata(Long runnerId, Long imageId) {
         return imageRepositoryPort.deleteById(runnerId, imageId)

--- a/src/main/java/com/aetheri/application/service/image/FindImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/FindImageMetadataService.java
@@ -12,12 +12,27 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터를 조회하기 위한 서비스
+ *
+ * @see FindImageMetadataService 구현하는 유즈케이스
+ * @see ImageRepositoryPort 데이터베이스에 접근하기 위해 접근하는 포트
+ * */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FindImageMetadataService implements FindImageMetadataUseCase {
     private final ImageRepositoryPort imageRepositoryPort;
 
+    /**
+     * 이미지 메타데이터를 조회하기 위한 메소드
+     *
+     * @implSpec 사용자 ID를 포함한 요청일 때 이 메소드를 사용한다.
+     * @param runnerId 이미지 메타데이터 조회를 요청한 사용자의 ID
+     * @param imageId 조회 요청된 이미지 메타데이터의 ID
+     * @return 이미지 메타데이터를 응답하는 DTO
+     * @exception BusinessException 이미지 메타데이터를 찾지 못했을 때 에러 반환
+     * */
     @Override
     public Mono<ImageMetadataResponse> findImageMetadataById(Long runnerId, Long imageId) {
         return imageRepositoryPort.findById(imageId)
@@ -37,6 +52,14 @@ public class FindImageMetadataService implements FindImageMetadataUseCase {
                 });
     }
 
+    /**
+     * 이미지 메타데이터를 조회하기 위한 메소드
+     *
+     * @implSpec 사용자 ID를 포함하지 않은 요청일 때 이 메소드를 사용한다.
+     * @param imageId 조회 요청된 이미지 메타데이터의 ID
+     * @return 이미지 메타데이터를 응답하는 DTO
+     * @exception BusinessException 이미지 메타데이터를 찾지 못했을 때 에러 반환
+     * */
     @Override
     public Mono<ImageMetadataResponse> findImageMetadataById(Long imageId) {
         return imageRepositoryPort.findById(imageId)

--- a/src/main/java/com/aetheri/application/service/image/FindImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/FindImageMetadataService.java
@@ -2,7 +2,7 @@ package com.aetheri.application.service.image;
 
 import com.aetheri.application.dto.image.ImageMetadataResponse;
 import com.aetheri.application.port.in.image.FindImageMetadataUseCase;
-import com.aetheri.domain.adapter.out.r2dbc.ImageMetadataRepositoryR2dbcAdapter;
+import com.aetheri.application.port.out.image.ImageRepositoryPort;
 import com.aetheri.domain.exception.BusinessException;
 import com.aetheri.domain.exception.message.ErrorMessage;
 import com.aetheri.infrastructure.persistence.entity.ImageMetadata;
@@ -16,11 +16,11 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class FindImageMetadataService implements FindImageMetadataUseCase {
-    private final ImageMetadataRepositoryR2dbcAdapter imageMetadataRepositoryR2DbcAdapter;
+    private final ImageRepositoryPort imageRepositoryPort;
 
     @Override
     public Mono<ImageMetadataResponse> findImageMetadataById(Long runnerId, Long imageId) {
-        return imageMetadataRepositoryR2DbcAdapter.findById(imageId)
+        return imageRepositoryPort.findById(imageId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorMessage.NOT_FOUND_IMAGE_METADATA, "이미지를 찾을 수 없습니다.")))
                 .flatMap(imageMetadata -> {
                     log.info("[FindImageMetadataMetadataService] 사용자 {}가 이미지 {}를 조회했습니다.", runnerId, imageId);
@@ -39,7 +39,7 @@ public class FindImageMetadataService implements FindImageMetadataUseCase {
 
     @Override
     public Mono<ImageMetadataResponse> findImageMetadataById(Long imageId) {
-        return imageMetadataRepositoryR2DbcAdapter.findById(imageId)
+        return imageRepositoryPort.findById(imageId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorMessage.NOT_FOUND_IMAGE_METADATA, "이미지를 찾을 수 없습니다.")))
                 .flatMap(imageMetadata -> {
                     log.info("[FindImageMetadataMetadataService] 이미지 {}를 조회했습니다.", imageId);
@@ -58,7 +58,7 @@ public class FindImageMetadataService implements FindImageMetadataUseCase {
 
     @Override
     public Flux<ImageMetadataResponse> findImageMetadataByRunnerId(Long runnerId) {
-        return imageMetadataRepositoryR2DbcAdapter.findByRunnerId(runnerId).map(ImageMetadata::toResponse)
+        return imageRepositoryPort.findByRunnerId(runnerId).map(ImageMetadata::toResponse)
                 .doOnComplete(() -> log.info("[FindImageMetadataMetadataService] 사용자 {}의 이미지를 조회했습니다.", runnerId));
     }
 }

--- a/src/main/java/com/aetheri/application/service/image/SaveImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/SaveImageMetadataService.java
@@ -9,15 +9,34 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터를 생성하기 위한 서비스
+ *
+ * @see SaveImageMetadataUseCase 구현하는 유즈케이스
+ * @see ImageRepositoryPort 데이터베이스에 접근하기 위해 접근하는 포트
+ * */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SaveImageMetadataService implements SaveImageMetadataUseCase {
     private final ImageRepositoryPort imageRepositoryPort;
 
+    /**
+     * 이미지 메타데이터를 생성하기 위한 메소드
+     * @implSpec 받아오지 않는 값은 자동으로 기본적인 값을 가진 항목들이다.
+     * @param runnerId 이미지 메타데이터를 생성한 사용자의 ID
+     * @param request 이미지 메타데이터 생성 요청
+     * @return 아무런 정보도 응답하지 않는다.
+     * */
     @Override
     public Mono<Void> saveImageMetadata(Long runnerId, ImageMetadataSaveRequest request) {
-        var imageMetadataSaveDto = new ImageMetadataSaveDto(runnerId, request.location(), request.shape(), request.proficiency());
+        var imageMetadataSaveDto = new ImageMetadataSaveDto(
+                runnerId,
+                request.location(),
+                request.shape(),
+                request.proficiency()
+        );
+
         return imageRepositoryPort.saveImageMetadata(imageMetadataSaveDto)
                 .doOnSuccess(l -> log.info("[SaveImageMetadataService] 사용자 {}가 이미지 {}를 생성했습니다.", runnerId, l))
                 .then();

--- a/src/main/java/com/aetheri/application/service/image/SaveImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/SaveImageMetadataService.java
@@ -3,7 +3,7 @@ package com.aetheri.application.service.image;
 import com.aetheri.application.dto.image.ImageMetadataSaveRequest;
 import com.aetheri.application.dto.image.ImageMetadataSaveDto;
 import com.aetheri.application.port.in.image.SaveImageMetadataUseCase;
-import com.aetheri.domain.adapter.out.r2dbc.ImageMetadataRepositoryR2dbcAdapter;
+import com.aetheri.application.port.out.image.ImageRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,12 +13,12 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class SaveImageMetadataService implements SaveImageMetadataUseCase {
-    private final ImageMetadataRepositoryR2dbcAdapter imageMetadataRepositoryR2dbcAdapter;
+    private final ImageRepositoryPort imageRepositoryPort;
 
     @Override
     public Mono<Void> saveImageMetadata(Long runnerId, ImageMetadataSaveRequest request) {
         var imageMetadataSaveDto = new ImageMetadataSaveDto(runnerId, request.location(), request.shape(), request.proficiency());
-        return imageMetadataRepositoryR2dbcAdapter.saveImageMetadata(imageMetadataSaveDto)
+        return imageRepositoryPort.saveImageMetadata(imageMetadataSaveDto)
                 .doOnSuccess(l -> log.info("[SaveImageMetadataService] 사용자 {}가 이미지 {}를 생성했습니다.", runnerId, l))
                 .then();
     }

--- a/src/main/java/com/aetheri/application/service/image/UpdateImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/UpdateImageMetadataService.java
@@ -8,12 +8,26 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+/**
+ * 이미지 메타데이터를 수정하기 위한 서비스
+ *
+ * @see UpdateImageMetadataUseCase 구현하는 유즈케이스
+ * @see ImageRepositoryPort 데이터베이스에 접근하기 위해 접근하는 포트
+ * */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UpdateImageMetadataService implements UpdateImageMetadataUseCase {
     private final ImageRepositoryPort imageRepositoryPort;
 
+    /**
+     * 이미지 메타데이터를 수정하기 위한 메소드
+     * @implSpec 사용자의 것이 아니면 수정할 수 없도록 두현함
+     * @param runnerId 수정을 요천한 사용자의 ID
+     * @param imageId 수정 요청된 이미지 메타데이터의 ID
+     * @param request 수정 요청
+     * @return 아무런 정보도 응답하지 않는다.
+     * */
     @Override
     public Mono<Void> updateImageMetadata(Long runnerId, Long imageId, ImageMetadataUpdateRequest request) {
         return imageRepositoryPort.updateImageMetadata(runnerId, imageId, request)

--- a/src/main/java/com/aetheri/application/service/image/UpdateImageMetadataService.java
+++ b/src/main/java/com/aetheri/application/service/image/UpdateImageMetadataService.java
@@ -2,7 +2,7 @@ package com.aetheri.application.service.image;
 
 import com.aetheri.application.dto.image.ImageMetadataUpdateRequest;
 import com.aetheri.application.port.in.image.UpdateImageMetadataUseCase;
-import com.aetheri.domain.adapter.out.r2dbc.ImageMetadataRepositoryR2dbcAdapter;
+import com.aetheri.application.port.out.image.ImageRepositoryPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,11 +12,11 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class UpdateImageMetadataService implements UpdateImageMetadataUseCase {
-    private final ImageMetadataRepositoryR2dbcAdapter imageMetadataRepositoryR2dbcAdapter;
+    private final ImageRepositoryPort imageRepositoryPort;
 
     @Override
     public Mono<Void> updateImageMetadata(Long runnerId, Long imageId, ImageMetadataUpdateRequest request) {
-        return imageMetadataRepositoryR2dbcAdapter.updateImageMetadata(runnerId, imageId, request)
+        return imageRepositoryPort.updateImageMetadata(runnerId, imageId, request)
                 .doOnSuccess(l -> log.info("[UpdateImageMetadataService] 사용자 {}가 이미지 {}의 메타데이터를 수정했습니다. 바뀐 행: {}", runnerId, imageId, l))
                 .then();
     }


### PR DESCRIPTION
### 📝 요약 (Summary)

<!---이 PR은 사용자 프로필 편집 기능을 추가하여 사용자가 자신의 이름, 이메일, 프로필 사진을 업데이트할 수 있도록 합니다.--->

이 PR은 구현된 이미지 메타데이터의 코드들을 JavaDocs를 사용하여 문서화하기 위한 PR입니다.

---

### 🚀 변경 배경 및 문제점 (Motivation / Problem Solved)

<!---
현재 사용자들은 가입 후에 자신의 프로필 정보를 변경할 수 없었습니다. 이로 인해 잘못된 정보가 입력되었을 때 수정이 불가능하다는 피드백이 있었고, 사용자 경험을 개선하기 위해 해당 기능을 추가하게 되었습니다.
Fixes #123 (사용자 프로필 정보 수정 기능 부재)
--->

기존에는 문서화가 부족하여 유지보수에 어려움이 있을 수 있었습니다. 이를 보완하기 위하여 문서화를 진행하였습니다.

---

### 🛠️ 변경 내용 상세 (Changes Made)

<!---
* 새로운 라우트 `/profile/edit`을 추가했습니다.
* 사용자 정보를 업데이트하는 `updateUserProfile` API 엔드포인트를 구현했습니다.
* 프로필 이미지 업로드를 위해 Cloudinary 서비스를 연동했으며, 해당 로직을 `uploadService.js`에 캡슐화했습니다.
* 프론트엔드에서는 `ProfileEditForm` 컴포넌트를 개발하여 사용자가 정보를 입력하고 제출할 수 있도록 했습니다.
--->

* 이미지 메타데이터 도메인과 관련된 유즈케이스, 서비스, 어댑터, 포트를 문서화하였습니다.
* 그리고 문서화 중 Service가 Port가 아닌 Adapter에 의존하는 것을 확인하고 Port에 의존하도록 리펙토링 하였습니다.

---

### 💡 구현 세부 사항 및 기술적 결정 (Implementation Details / Technical Decisions)

<!---로필 사진 저장 시 S3 대신 Cloudinary를 선택한 이유는 이미지 최적화 및 CDN 기능을 내장하고 있어 추가적인 작업 없이 성능을 확보할 수 있다고 판단했기 때문입니다.--->

Javadocs로 문서화한 이유는 개발자가 사용할 수 있는 가장 작은 단위의 문서화 툴이기 때문입니다. 추후 Wiki에도 문서화할 예정입니다.

---

### 🧪 테스트 방법 (How to Test)

<!---
1.  로컬에서 프로젝트를 실행합니다: `npm install` 후 `npm start`
2.  브라우저에서 `http://localhost:3000/profile/edit` 에 접속합니다.
3.  로그인한 사용자 계정으로 (예: `testuser@example.com` / `password123`) 로그인합니다.
4.  이름, 이메일, 프로필 사진을 변경해보고 '저장' 버튼을 클릭합니다.
5.  데이터베이스에 변경된 정보가 올바르게 반영되었는지 확인합니다.
--->

비즈니스 로직 변경이 없었기 떄문에 명시하지 않습니다.


---

### 📸 스크린샷 (Screenshots)

<img width="1017" height="672" alt="image" src="https://github.com/user-attachments/assets/f4bc7289-aaa7-402d-8d6b-61edb1135aeb" />


---

### ⚠️ 추가 코멘트 (Additional Notes)

<!---현재는 프로필 사진 변경 시 이전 사진을 삭제하는 로직은 없습니다. (향후 개선 예정)--->

이미지 메타데이터 기능이 구현된 것을 선제적으로 문서화하였습니다. 추후 이미지(png 파일 조회)기능이 구현되면 따로 문서화할 것입니다.